### PR TITLE
Adding Apache version 2.0 to license text

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,11 +256,13 @@ layout: default
             <h2>About</h2>
 
             <p>
-                cloud-init is developed and released as free software under the
+                cloud-init is developed and released as free software under both the
                 <a href="http://www.gnu.org/licenses/gpl-3.0.en.html">GPLv3 open source
-                license</a>. It was originally designed for the <a href="http://www.ubuntu.com/">
-                Ubuntu</a> distribution of Linux in Amazon EC2, but is now supported on many
-                Linux and UNIX distributions in every major cloud.
+                license</a> and <a href="https://www.apache.org/licenses/LICENSE-2.0">
+                Apache License version 2.0</a>. It was originally designed for the
+                <a href="http://www.ubuntu.com/">Ubuntu</a> distribution of Linux in
+                Amazon EC2, but is now supported on many Linux and UNIX distributions in
+                every major cloud.
             </p>
         </div>
 


### PR DESCRIPTION
cloud-init is now dual licensed under the GPLv3 and Apache v2 after the following commit:
https://git.launchpad.net/cloud-init/commit/?id=b2a9f33616c806ae6e052520a8589113308f567c

## Done

Added dual licensed comments.

## QA

None

## Issue / Card

Fixes #51 

## Screenshots

[if relevant, include a screenshot]
