### PR TITLE
Updating IRC Links

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,9 +226,9 @@ layout: default
             </div>
             <div class="three-col box">
                 <h3>
-                    <a class="external" href="http://pingx.net/freenode/cloud-init">Chat on freenode</a>
+                    <a class="external" href="https://webchat.freenode.net/">Chat on freenode</a>
                 </h3>
-                <p>We have an active IRC community &mdash; get involved!</p>
+                <p>We have an active IRC community on #cloud-init &mdash; get involved!</p>
             </div>
             <div class="three-col box">
                 <h3>


### PR DESCRIPTION
## Done

Rather than linking to IRC logs that are not updated, provide a
direct link to Freenode's web client. The logs are old and not
updated and this provides a better user experience.

## QA

None

## Issue / Card

Fixes #54 
