### PR TITLE
Fix os links

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,8 +147,8 @@ layout: default
         <div class="equal-height">
             <div class="four-col card">
                 <img class="card__img" src="https://assets.ubuntu.com/v1/2d779aa4-bazaar+%281%29.svg" alt="Bazaar logo">
-                <h3>Bazaar</h3>
-                <p>Browse and branch from Bazaar.</p>
+                <h3>Git</h3>
+                <p>Browse and branch from Git.</p>
                 <a class="external card__link" href="https://code.launchpad.net/cloud-init">Bazaar repository</a>
             </div>
 
@@ -156,7 +156,7 @@ layout: default
                 <img class="card__img" src="https://assets.ubuntu.com/v1/e59251d7-github.svg" alt="GitHub logo">
                 <h3>GitHub</h3>
                 <p>Browse, branch, fork or clone from GitHub.</p>
-                <a class="external card__link" href="https://github.com/openstack/cloud-init">GitHub repository</a>
+                <a class="external card__link" href="https://github.com/cloud-init/cloud-init">GitHub repository</a>
             </div>
 
             <div class="four-col last-col card">

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@ layout: default
             </li>
 
             <li class="box three-col last-col">
-                <a href="http://packages.qa.debian.org/c/cloud-init.html">
+                <a href="https://copr.fedorainfracloud.org/coprs/g/cloud-init/cloud-init/">
                     <div class="box__img-wrap">
                         <img class="box__img" src="https://assets.ubuntu.com/v1/6947a9e3-redhat.svg" alt="RedHat logo">
                     </div>
@@ -129,7 +129,7 @@ layout: default
             </li>
 
             <li class="box three-col last-col">
-                <a href="https://susestudio.com/">
+                <a href="https://software.opensuse.org/package/cloud-init">
                     <div class="box__img-wrap">
                         <img class="box__img" src="https://assets.ubuntu.com/v1/2e497b2e-opensuse.svg" alt="OpenSUSE logo">
                     </div>


### PR DESCRIPTION
## Done

Fixes RHEL link to not point at Debian incorrectly, but at our own COPR repo that we use. Updates the SUSE link as well to open suse's own package repo.

## QA

None

## Issue / Card

Fixes #53 
