### PR TITLE
Update links and bazaar naming

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@ layout: default
         <footer class="p-card__footer">
           <a class="p-link--external"
             aria-label="External link to CentOS cloud images page"
-            href="https://cloud.centos.org/centos/7/images/">Get packages</a>
+            href="https://copr.fedorainfracloud.org/coprs/g/cloud-init/cloud-init/">Get packages</a>
         </footer>
       </div>
       <div class="p-card col-3">
@@ -115,7 +115,7 @@ layout: default
         <footer class="p-card__footer">
           <a class="p-link--external"
             aria-label="External link to Debian package page for cloud-init"
-            href="https://packages.qa.debian.org/c/cloud-init.html">
+            href="https://copr.fedorainfracloud.org/coprs/g/cloud-init/cloud-init/">
             Get packages
           </a>
         </footer>
@@ -147,7 +147,7 @@ layout: default
         <footer class="p-card__footer">
           <a class="p-link--external"
             aria-label="External link to Fedoras cloud images page"
-            href="https://getfedora.org/en/cloud/download/">
+            href="https://copr.fedorainfracloud.org/coprs/g/cloud-init/cloud-init/">
             Get packages
           </a>
         </footer>
@@ -175,7 +175,7 @@ layout: default
         <footer class="p-card__footer">
           <a class="p-link--external"
             aria-label="External link to cloud-inits source files on launchpad"
-            href="https://launchpad.net/ubuntu/+source/cloud-init">
+            href="https://build.opensuse.org/package/show/Cloud:Tools/cloud-init">
             Get packages
           </a>
         </footer>
@@ -203,7 +203,7 @@ layout: default
           <a class="p-link--external"
             aria-label="External link to cloud-inits source files on launchpad"
             href="https://code.launchpad.net/cloud-init">
-            Bazaar repository
+            Git repository
           </a>
         </footer>
       </div>


### PR DESCRIPTION
## Done
This updates the download links to the various OSes. For the
Red Hat based OSes it points at the COPR repo that contains downloads
for CentOS, Red Hat, and Fedora. Updates the openSUSE link as well
to point at the Open Build Service.

As a drive by it also removes "bazaar" from the source code link.

## QA

None

## Issue / Card

Fixes #64
