### PR TITLE
Align text to all 8 columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,12 +32,12 @@ layout: default
         that gives every cloud instance its personality and cloud-init is the
         tool applies user data to your instances automatically.
       </p>
-      <p>Use cloud-init to configure:</p>
     </div>
   </div>
   <div class="row">
     <div class="col-12">
-      <ul class="p-list is-split u-no-margin--top">
+      <h5>Use cloud-init to configure:</h5>
+      <ul class="p-list">
         <li class="p-list__item is-ticked">Setting a default locale</li>
         <li class="p-list__item is-ticked">Setting the hostname</li>
         <li class="p-list__item is-ticked">
@@ -53,7 +53,7 @@ layout: default
 
 <section class="p-strip is-deep is-bordered">
   <div class="row">
-    <div class="col-9">
+    <div class="col-8">
       <h2>Works with many popular operating systems</h2>
       <p>
         While cloud-init started life in Ubuntu, it is now available for most


### PR DESCRIPTION
## Done
Align text by setting them to `col-8` and tidied up the bullet section as requested in the issue.

## QA
- Run `./run`
- Open http://0.0.0.0:8009/
- Check that the "Works with many popular operating systems" section is now in a `col-8`

## Issue / Card
Fixes https://github.com/canonical-websites/cloud-init.io/issues/66

## Screenshots
![0 0 0 0-8009- 1](https://user-images.githubusercontent.com/1413534/28714913-822f0f00-738d-11e7-8373-5a984c2d5ad1.png)

