### PR TITLE
Fix typo on the homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@ layout: default
         Cloud images are operating system templates and every instance starts
         out as an identical clone of every other instance. It is the user data
         that gives every cloud instance its personality and cloud-init is the
-        tool applies user data to your instances automatically.
+        tool that applies user data to your instances automatically.
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Done
Fixed a simple typo on the homepage

## QA
- Run `./run`
- Open http://0.0.0.0:8009/
- Check for the existence of "the tool **that** applies user data to your instances automatically." not "the tool applies user data to your instances automatically." 

## Issue / Card
Fixes https://github.com/canonical-websites/cloud-init.io/issues/70