### PR TITLE
cloud-init.io upgrade vanilla-framework to v1.7.0-alpha-1

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ layout: default
   <div class="row">
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
-        <a class="p-navigation__link" href="https://cloud-init.io">
+        <a class="p-navigation__link" href="/">
             <img src="https://assets.ubuntu.com/v1/d9c7e58e-cloud-init-logo-updated.svg" alt="" class="p-navigation__image">
           </a>
       </div>

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "gulp-sass": "^2.1.1",
     "gulp-sourcemaps": "*",
     "npm": "*",
-    "vanilla-framework": "1.6.5",
+    "vanilla-framework": "1.7.0-alpha-1",
     "watch-cli": "^0.2.2",
     "sass-lint": "^1.10.2",
     "postcss-cli": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5231,9 +5231,9 @@ validate-npm-package-name@^3.0.0, validate-npm-package-name@~3.0.0:
   dependencies:
     builtins "^1.0.3"
 
-vanilla-framework@1.6.5:
-  version "1.6.5"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.6.5.tgz#e6ea7ab6de38c8172e362474258981a57eec0993"
+vanilla-framework@1.7.0-alpha-1:
+  version "1.7.0-alpha-1"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.7.0-alpha-1.tgz#cbf6ce65c97a3cece65a0bb6274904cf81918b94"
 
 vendors@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
## Done
Updated vanilla-framework to 1.7.0-alpha-1 and changed the logo link to be relative.

## QA
Check out the demo and see if there are issues.