### PR TITLE
Fixes grammar error

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,7 +211,7 @@ layout: default
             <a class="p-link--external" aria-label="External link to cloud-inits documentation on read the docs" href="https://cloudinit.readthedocs.org/">Read the docs</a>
           </h4>
           <p>
-            Always read the manual &mdash; perhaps your question has already be answered?
+            Including datasource and module references, and plenty of examples.
           </p>
         </div>
         <div class="col-6 p-card">


### PR DESCRIPTION
## Done

Changes the description of the documentation from

“Always read the manual — perhaps your question has already be answered?”

to 

“Including datasource and module references, and plenty of examples.”

Fixes the grammar error, and avoids assuming that your problem is that you haven‘t read the manual.