### PR TITLE
Removes incorrect aria-label attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@ layout: default
     <div class="col-8">
       <h1>cloud-init</h1>
       <p class="p-heading--four">The standard for customising cloud instances</p>
-      <a class="p-button--positive" aria-label="Watch YouTube video introducing Ubuntu cloud-init" href="https://www.youtube.com/watch?v=-zL3BdbKyGY">
+      <a class="p-button--positive" href="https://www.youtube.com/watch?v=-zL3BdbKyGY">
         <span class="p-link--external">Watch tutorial</span>
       </a>
     </div>
@@ -69,25 +69,25 @@ layout: default
           <header class="p-card__header">
             <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="Ubuntu logo">
           </header>
-          <a class="p-link--external" aria-label="External link to the source files for cloud-init" href="https://launchpad.net/ubuntu/+source/cloud-init">Get packages</a>
+          <a class="p-link--external" href="https://launchpad.net/ubuntu/+source/cloud-init">Get packages</a>
         </div>
         <div class="p-card col-3">
           <header class="p-card__header">
             <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/e0b23092-archlinux.svg" alt="Arch Linux logo">
           </header>
-          <a class="p-link--external" aria-label="External link to the source files for cloud-init" href="https://wiki.archlinux.org/index.php/Cloud-init">Get packages</a>
+          <a class="p-link--external" href="https://wiki.archlinux.org/index.php/Cloud-init">Get packages</a>
         </div>
         <div class="p-card col-3">
           <header class="p-card__header">
             <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/c69a8b3c-centos-logo.png" alt="CentOS logo">
           </header>
-          <a class="p-link--external" aria-label="External link to the source files for cloud-init" href="https://copr.fedorainfracloud.org/coprs/g/cloud-init/el-stable/">Get packages</a>
+          <a class="p-link--external" href="https://copr.fedorainfracloud.org/coprs/g/cloud-init/el-stable/">Get packages</a>
         </div>
         <div class="p-card col-3">
           <header class="p-card__header">
             <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/6947a9e3-redhat.svg" alt="Red Hat logo">
           </header>
-          <a class="p-link--external" aria-label="External link to the source files for cloud-init" href="https://copr.fedorainfracloud.org/coprs/g/cloud-init/el-stable/">Get packages</a>
+          <a class="p-link--external" href="https://copr.fedorainfracloud.org/coprs/g/cloud-init/el-stable/">Get packages</a>
         </div>
       </div>
       <div class="row">
@@ -96,25 +96,25 @@ layout: default
             <header class="p-card__header">
               <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/65ab4aca-FREEBSD_Logo_Horiz_Pos_RGB.png" alt="FreeBSD logo">
             </header>
-            <a class="p-link--external" aria-label="External link to the source files for cloud-init" href="https://pellaeon.github.io/bsd-cloudinit">Get packages</a>
+            <a class="p-link--external" href="https://pellaeon.github.io/bsd-cloudinit">Get packages</a>
           </div>
           <div class="p-card col-3">
             <header class="p-card__header">
               <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/1a53bedd-fedora.svg" alt="Fedora logo">
             </header>
-            <a class="p-link--external" aria-label="External link to the source files for cloud-init" href="https://koji.fedoraproject.org/koji/packageinfo?packageID=12620">Get packages</a>
+            <a class="p-link--external" href="https://koji.fedoraproject.org/koji/packageinfo?packageID=12620">Get packages</a>
           </div>
           <div class="p-card col-3">
             <header class="p-card__header">
               <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/ef4f2511-gentoo-type-logo.svg" alt="Gentoo Linux logo">
             </header>
-            <a class="p-link--external" aria-label="External link to the source files for cloud-init" href="https://packages.gentoo.org/package/app-emulation/cloud-init">Get packages</a>
+            <a class="p-link--external" href="https://packages.gentoo.org/package/app-emulation/cloud-init">Get packages</a>
           </div>
           <div class="p-card col-3">
             <header class="p-card__header">
               <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/f0b014a6-OpenSUSE_Logo.svg" alt="OpenSUSE logo">
             </header>
-            <a class="p-link--external" aria-label="External link to the source files for cloud-init" href="https://build.opensuse.org/package/show/Cloud:Tools/cloud-init">Get packages</a>
+            <a class="p-link--external" href="https://build.opensuse.org/package/show/Cloud:Tools/cloud-init">Get packages</a>
           </div>
         </div>
       </div>
@@ -137,7 +137,7 @@ layout: default
           </header>
           <h3 class="p-card__title">Git</h3>
           <p class="p-card__content">Browse and branch from Git.</p>
-          <a class="p-link--external" aria-label="External link to cloud-inits source files on launchpad" href="https://code.launchpad.net/cloud-init">Git repository</a>
+          <a class="p-link--external" href="https://code.launchpad.net/cloud-init">Git repository</a>
         </div>
         <div class="p-card col-4">
           <header class="p-card__header">
@@ -145,7 +145,7 @@ layout: default
           </header>
           <h3 class="p-card__title">GitHub</h3>
           <p class="p-card__content">Browse, branch, fork or clone from GitHub.</p>
-          <a class="p-link--external" aria-label="External link to cloud-inits source files on launchpad" href="https://github.com/cloud-init/cloud-init">GitHub repository</a>
+          <a class="p-link--external" href="https://github.com/cloud-init/cloud-init">GitHub repository</a>
         </div>
         <div class="p-card col-4">
           <header class="p-card__header">
@@ -153,7 +153,7 @@ layout: default
           </header>
           <h3 class="p-card__title">Download</h3>
           <p class="p-card__content">Download the offically released archives.</p>
-          <a class="p-link--external" aria-label="External link to cloud-inits source files on launchpad" href="https://launchpad.net/cloud-init/+download">Download project files</a>
+          <a class="p-link--external" href="https://launchpad.net/cloud-init/+download">Download project files</a>
         </div>
       </div>
     </div>
@@ -191,7 +191,7 @@ layout: default
         </li>
       </ul>
       <p class="u-align-text--center">
-        <a href="https://partners.ubuntu.com/find-a-partner?programme=certified-public-cloud" aria-label="External link to Ubuntus certified public cloud partners" class="p-link--external">See our other Ubuntu public cloud partners</a>
+        <a href="https://partners.ubuntu.com/find-a-partner?programme=certified-public-cloud" class="p-link--external">See our other Ubuntu public cloud partners</a>
       </p>
     </div>
   </div>
@@ -208,7 +208,7 @@ layout: default
       <div class="u-equal-height">
         <div class="col-6 p-card">
           <h4>
-            <a class="p-link--external" aria-label="External link to cloud-inits documentation on read the docs" href="https://cloudinit.readthedocs.org/">Read the docs</a>
+            <a class="p-link--external" href="https://cloudinit.readthedocs.org/">Read the docs</a>
           </h4>
           <p>
             Always read the manual &mdash; perhaps your question has already be answered?
@@ -216,7 +216,7 @@ layout: default
         </div>
         <div class="col-6 p-card">
           <h4>
-            <a class="p-link--external" aria-label="External link freenodes web portal" href="https://webchat.freenode.net/">Chat on freenode</a>
+            <a class="p-link--external" href="https://webchat.freenode.net/">Chat on freenode</a>
           </h4>
           <p>We have an active IRC community on #cloud-init &mdash; get involved!</p>
         </div>
@@ -226,13 +226,13 @@ layout: default
       <div class="u-equal-height">
         <div class="col-6 p-card">
           <h4>
-            <a class="p-link--external" aria-label="External link to cloud-init questions on stackexchange" href="https://stackexchange.com/search?q=cloud-init">Search on Stack Exchange</a>
+            <a class="p-link--external" href="https://stackexchange.com/search?q=cloud-init">Search on Stack Exchange</a>
           </h4>
           <p>Ask questions and search for answers at StackExchange.</p>
         </div>
         <div class="col-6 p-card">
           <h4>
-            <a class="p-link--external" aria-label="External link to cloud-inits bugs on launchpad" href="https://bugs.launchpad.net/cloud-init/+filebug">Report a bug</a>
+            <a class="p-link--external" href="https://bugs.launchpad.net/cloud-init/+filebug">Report a bug</a>
           </h4>
           <p>Help us improve the software by flagging bugs and issues you find on Launchpad.</p>
         </div>
@@ -247,9 +247,9 @@ layout: default
       <h2>About</h2>
       <p>
         cloud-init is developed and released as free software under both the
-        <a class="p-link--external" aria-label="External link to GPLv3 open source license web page" href="https://www.gnu.org/licenses/gpl-3.0.en.html">GPLv3 open source license</a>
-        and <a class="p-link--external" aria-label="External link to Apache's license 2.0" href="https://www.apache.org/licenses/LICENSE-2.0">Apache License version 2.0</a>.
-        It was originally designed for the <a class="p-link--external" aria-label="External link to Ubuntu's main website" href="https://www.ubuntu.com/">Ubuntu</a>
+        <a class="p-link--external" href="https://www.gnu.org/licenses/gpl-3.0.en.html">GPLv3 open source license</a>
+        and <a class="p-link--external" href="https://www.apache.org/licenses/LICENSE-2.0">Apache License version 2.0</a>.
+        It was originally designed for the <a class="p-link--external" href="https://www.ubuntu.com/">Ubuntu</a>
         distribution of Linux in Amazon EC2, but is now supported on many Linux and UNIX distributions in every major cloud.
       </p>
     </div>
@@ -269,8 +269,8 @@ layout: default
         <div class="p-media-object__details">
           <h3 class="p-media-object__title">Scott Moser</h3>
           <p class="p-media-object__content">
-            <a class="p-link--external" aria-label="External link to Scott Moser blog" href="https://ubuntu-smoser.blogspot.co.uk/">Scott</a> is the primary author and active maintainer of cloud-init, and is a technical leader on the Ubuntu Server Team for
-            <a class="p-link--external" aria-label="External link to Canonical website" href="https://www.canonical.com/">Canonical</a>.
+            <a class="p-link--external" href="https://ubuntu-smoser.blogspot.co.uk/">Scott</a> is the primary author and active maintainer of cloud-init, and is a technical leader on the Ubuntu Server Team for
+            <a class="p-link--external" href="https://www.canonical.com/">Canonical</a>.
           </p>
         </div>
       </div>
@@ -281,8 +281,8 @@ layout: default
         <div class="p-media-object__details">
           <h3 class="p-media-object__title">Joshua Harlow</h3>
           <p class="p-media-object__content">
-            <a class="p-link--external" aria-label="External link to Joshua Harlow profile on Launchpad" href="https://launchpad.net/~harlowja">Joshua</a> is an active maintainer of cloud-init, hacking on clouds for
-            <a class="p-link--external" aria-label="External link to GoDaddy website" href="https://www.godaddy.com/">GoDaddy</a>.
+            <a class="p-link--external" href="https://launchpad.net/~harlowja">Joshua</a> is an active maintainer of cloud-init, hacking on clouds for
+            <a class="p-link--external" href="https://www.godaddy.com/">GoDaddy</a>.
           </p>
         </div>
       </div>


### PR DESCRIPTION
The `aria-label` attribute is for labelling items that (1) do not have a sufficient text label because (2) they rely on their visual appearance or layout to be understood. References: [WAI](https://www.w3.org/WAI/GL/wiki/Using_aria-label_to_provide_an_invisible_label), [WCAG 2.0](https://www.w3.org/TR/WCAG20-TECHS/ARIA14.html), [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute).

Every use of `aria-label` on this page is inappropriate, because it’s for an element that (1) already has a sufficient text label, that is, the contents of the link or button.

(In addition, many of the `aria-label` values are factually incorrect — claiming to link to “source files” when they’re actually packages, or claiming that a link is to something “on launchpad” when it’s on GitHub.)

The `aria-label`s _do_ contain a few correct details that are not in the visible labels: for example, that the video is a “YouTube video”, or that Ubuntu’s cloud partners are “certified”. But there’s no reason that those details should be available to people who can’t see the page, and not to people who can! They’re either relevant to readers in general, or they aren’t. If they are, they should be included in the visible labels, or else in a `title` attribute where they’re available to sighted and unsighted users alike.

The one detail that isn’t and shouldn’t be in existing text labels, because (2) it’s obvious from the visual design instead, is that the links are “external”. But that isn’t interesting on this page, because _every_ link on the page is external.