### PR TITLE
Fix typo: “offically” → “officially”

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@ layout: default
             <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/d656d6b1-picto-download-orange.svg" alt="Download logo">
           </header>
           <h3 class="p-card__title">Download</h3>
-          <p class="p-card__content">Download the offically released archives.</p>
+          <p class="p-card__content">Download the officially released archives.</p>
           <a class="p-link--external" href="https://launchpad.net/cloud-init/+download">Download project files</a>
         </div>
       </div>


### PR DESCRIPTION
## Done

`git grep -l "offically" | xargs sed -i "s/offically/officially/g"`

## QA

None.

## Issue / Card

None.

## Screenshots

![captura de pantalla de 2018-09-20 06-04-45](https://user-images.githubusercontent.com/554953/45814415-1ef31500-bc9b-11e8-99f2-5d38218810d8.png)

